### PR TITLE
feat: add Broker.from_store() factory classmethod

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,11 @@ cassette = store.load()  # Returns empty Cassette if file doesn't exist
 You can also use `Broker.from_store()` to load the cassette and create a broker in one step:
 
 ```python
-store = JsonFileCassetteStore(Path("cassettes/my_test.json"))
-broker = Broker.from_store(store, mode="replay")
+store = JsonFileCassetteStore(
+    Path("cassettes/my_test.json"),
+    create_if_missing=True,
+)
+broker = Broker.from_store(store, mode="auto", live_responder=my_live_responder)
 ```
 
 The `JsonFileCassetteStore` creates parent directories automatically when saving.

--- a/README.md
+++ b/README.md
@@ -314,6 +314,13 @@ broker = Broker(
 response = list(broker.replay(request))
 ```
 
+You can also use `Broker.from_store()` to load the cassette and create a broker in one step:
+
+```python
+store = JsonFileCassetteStore(Path("cassettes/my_test.json"))
+broker = Broker.from_store(store, mode="replay")
+```
+
 The `JsonFileCassetteStore` creates parent directories automatically when saving.
 If saving fails, the error is propagated and response streaming stops (fail-fast).
 

--- a/e2e/specs/persistence.spec
+++ b/e2e/specs/persistence.spec
@@ -50,20 +50,18 @@
 
 ## Broker created via from_store replays recorded interaction
 
-* Create empty cassette
 * Configure mock live responder returning "from-store-data"
-* Configure JSON file cassette store at temporary path
-* Storing broker in "record" mode receives request for "test-proto" "fetch" "resource-123"
+* Configure JSON file cassette store with create_if_missing at temporary path
+* Create broker from store in "record" mode
+* Broker replays request for "test-proto" "fetch" "resource-123"
 * Create broker from store in "replay" mode
 * Broker replays request for "test-proto" "fetch" "resource-123"
 * Response stream should contain "from-store-data"
 
 ## Broker created via from_store with auto mode forwards MISS to live responder
 
-* Create empty cassette
 * Configure mock live responder returning "live-auto-data"
-* Configure JSON file cassette store at temporary path
-* Save current cassette to file store
+* Configure JSON file cassette store with create_if_missing at temporary path
 * Create broker from store in "auto" mode
 * Broker replays request for "test-proto" "fetch" "resource-999"
 * Response stream should contain "live-auto-data"

--- a/e2e/specs/persistence.spec
+++ b/e2e/specs/persistence.spec
@@ -18,3 +18,23 @@
 * Load cassette from file store
 * Broker in "replay" mode receives request for "test-proto" "fetch" "resource-123"
 * Response stream should contain "persisted-data"
+
+## Broker created via from_store replays recorded interaction
+
+* Create empty cassette
+* Configure mock live responder returning "from-store-data"
+* Configure JSON file cassette store at temporary path
+* Storing broker in "record" mode receives request for "test-proto" "fetch" "resource-123"
+* Create broker from store in "replay" mode
+* Broker replays request for "test-proto" "fetch" "resource-123"
+* Response stream should contain "from-store-data"
+
+## Broker created via from_store with auto mode forwards MISS to live responder
+
+* Create empty cassette
+* Configure mock live responder returning "live-auto-data"
+* Configure JSON file cassette store at temporary path
+* Save current cassette to file store
+* Create broker from store in "auto" mode
+* Broker replays request for "test-proto" "fetch" "resource-999"
+* Response stream should contain "live-auto-data"

--- a/e2e/step_impl/step_impl.py
+++ b/e2e/step_impl/step_impl.py
@@ -520,14 +520,6 @@ def broker_replays_request(protocol: str, action: str, target: str) -> None:
         data_store.scenario["error"] = e
 
 
-@step("Save current cassette to file store")
-def save_current_cassette_to_file_store() -> None:
-    """Save the current cassette to the configured file store."""
-    cassette = cast("Cassette", data_store.scenario["cassette"])
-    store = cast("JsonFileCassetteStore", data_store.scenario["cassette_store"])
-    store.save(cassette)
-
-
 @step("Cassette file should exist at configured path")
 def cassette_file_should_exist() -> None:
     """Verify that the cassette file exists."""

--- a/src/interposition/_version.py
+++ b/src/interposition/_version.py
@@ -1,3 +1,3 @@
 """Version information for interposition."""
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"

--- a/src/interposition/services.py
+++ b/src/interposition/services.py
@@ -87,6 +87,10 @@ class Broker:
 
         Returns:
             A new Broker instance with the loaded cassette.
+
+        Raises:
+            CassetteLoadError: When the store fails to load the cassette
+                (e.g., missing file, corrupted data).
         """
         cassette = cassette_store.load()
         return cls(

--- a/src/interposition/services.py
+++ b/src/interposition/services.py
@@ -71,6 +71,31 @@ class Broker:
         self._live_responder = live_responder
         self._cassette_store = cassette_store
 
+    @classmethod
+    def from_store(
+        cls,
+        cassette_store: CassetteStore,
+        mode: BrokerMode = "replay",
+        live_responder: LiveResponder | None = None,
+    ) -> Broker:
+        """Create a Broker by loading a cassette from a store.
+
+        Args:
+            cassette_store: The store to load the cassette from
+            mode: The broker mode (replay, record, or auto)
+            live_responder: Optional callable for upstream forwarding
+
+        Returns:
+            A new Broker instance with the loaded cassette.
+        """
+        cassette = cassette_store.load()
+        return cls(
+            cassette=cassette,
+            mode=mode,
+            live_responder=live_responder,
+            cassette_store=cassette_store,
+        )
+
     @property
     def cassette(self) -> Cassette:
         """Get the cassette."""

--- a/src/interposition/services.py
+++ b/src/interposition/services.py
@@ -11,6 +11,8 @@ from interposition.models import Cassette, Interaction
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from typing_extensions import Self
+
     from interposition.models import InteractionRequest, ResponseChunk
 
 BrokerMode = Literal["replay", "record", "auto"]
@@ -77,7 +79,7 @@ class Broker:
         cassette_store: CassetteStore,
         mode: BrokerMode = "replay",
         live_responder: LiveResponder | None = None,
-    ) -> Broker:
+    ) -> Self:
         """Create a Broker by loading a cassette from a store.
 
         Args:


### PR DESCRIPTION
# Pull Request Overview

Add `Broker.from_store()` factory classmethod that loads a cassette from a store and creates a Broker in one step, simplifying the common pattern of load-then-construct.

## Changes

| Category | File | Description |
|----------|------|-------------|
| Core | `src/interposition/services.py` | Add `Broker.from_store()` classmethod |
| Tests | `tests/unit/test_broker.py` | Unit tests for `from_store()` (cassette loading, mode, live_responder) |
| E2E | `e2e/specs/persistence.spec` | E2E scenarios for record/replay and auto mode via `from_store()` |
| E2E | `e2e/step_impl/step_impl.py` | Step implementations for `from_store()` E2E scenarios |
| Docs | `README.md` | Usage example for `Broker.from_store()` |

## Related Issues

Closes #10

## Test Details

- 3 unit tests covering: cassette loading, mode parameter, live_responder passthrough
- 2 E2E scenarios: record-then-replay via `from_store()`, auto mode with cache miss forwarding

## Future Work

None identified.

## Notes

The `from_store()` method delegates to `cassette_store.load()` and passes all parameters through to the existing `__init__`, keeping the implementation minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-step initialization to load a cassette from a store and create a broker, supporting replay, record, and auto modes.

* **Documentation**
  * Added a usage example demonstrating the one-step initialization with create-if-missing and auto mode.

* **Tests**
  * Added unit and end-to-end tests verifying broker creation from a store, replaying recorded interactions, and auto mode forwarding misses to live responder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->