### PR TITLE
Feature/require live responder auto record

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,8 +7,13 @@
 ## Related Issues
 <!-- List any related issue numbers -->
 
-## Test Details
-<!-- Describe the testing performed and steps taken -->
+## Review Checklist
+<!-- Items that CI does not cover — check before merging -->
+- [ ] Version bump evaluated (is a minor/patch bump needed?)
+- [ ] No breaking changes to public API (if any, is a major bump planned?)
+- [ ] Documentation reflects all changes (README, API reference, E2E specs page)
+- [ ] No non-trivial design decisions left without an ADR
+- [ ] No existing ADR revisit triggers fired by this change
 
 ## Future Work
 <!-- List any tasks or issues to be addressed in the future -->

--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ except InterpositionError as e:
     print(f"Interposition error: {e}")
 ```
 
-**InteractionNotFoundError**: Raised when no matching interaction exists (in `replay` mode) or when `auto` mode has a cache miss without a configured `live_responder`:
+**InteractionNotFoundError**: Raised when no matching interaction exists in `replay` mode:
 
 ```python
 from interposition import InteractionNotFoundError
@@ -361,15 +361,13 @@ except InteractionNotFoundError as e:
     print(f"Not recorded: {e.request.target}")
 ```
 
-**LiveResponderRequiredError**: Raised when `record` mode is used without a `live_responder`:
+**LiveResponderRequiredError**: Raised at broker construction when `record` or `auto` mode is used without a `live_responder`:
 
 ```python
 from interposition import LiveResponderRequiredError
 
-broker = Broker(cassette=cassette, mode="record")  # No live_responder!
-
 try:
-    broker.replay(request)
+    Broker(cassette=cassette, mode="auto")  # No live_responder!
 except LiveResponderRequiredError as e:
     print(f"live_responder required for {e.mode} mode")
 ```

--- a/docs/adr/0014-require-live-responder-for-auto-mode.md
+++ b/docs/adr/0014-require-live-responder-for-auto-mode.md
@@ -1,0 +1,81 @@
+# ADR 0014: Require live_responder for Auto and Record Modes at Construction
+
+## Status
+
+Accepted
+
+## Date
+
+2026-02-25
+
+## Context
+
+`Broker` supports three modes:
+
+1. `replay`: replay from cassette only
+2. `record`: always forward to live upstream and record
+3. `auto`: replay on HIT, forward-and-record on MISS
+
+Before this decision, `Broker` could be constructed in `auto` (and `record`) mode without `live_responder`. In those cases, errors surfaced later during request handling when forwarding was needed.
+
+This allowed a partially valid runtime configuration and delayed misconfiguration detection. The project prioritizes deterministic testing and fail-fast behavior, so configuration errors should be detected as early as possible.
+
+## Decision
+
+`Broker` must enforce `live_responder` availability at construction time for both `record` and `auto` modes.
+
+- If `mode` is `record` or `auto` and `live_responder` is `None`, raise `LiveResponderRequiredError(mode)` from `Broker.__init__`.
+- `Broker.from_store(...)` inherits the same invariant by constructing through `Broker.__init__`.
+- `replay` mode continues to allow `live_responder=None`.
+
+## Rationale
+
+- **Fail-fast configuration validation**: invalid mode/responder combinations are rejected immediately.
+- **Determinism-first behavior**: avoids hidden runtime branches where missing upstream configuration appears only under specific traffic patterns.
+- **Consistent mode contract**: both forwarding-capable modes (`record`, `auto`) require forwarding capability at setup time.
+- **Operational clarity**: users preparing `auto` for cassette extension workflows are required to wire upstream explicitly.
+
+## Implications
+
+### Positive Implications
+
+- Misconfiguration is caught at broker creation, not during replay.
+- API behavior is stricter and easier to reason about in tests and CI.
+- E2E and unit tests can assert configuration validity directly.
+
+### Concerns
+
+- **Breaking change**: existing `auto` usages that relied on replay-only HIT paths without a `live_responder` will fail at initialization (mitigation: document this clearly in release notes and migration guidance, with before/after examples).
+- Slightly reduced flexibility for niche `auto` scenarios that never MISS (mitigation: use `replay` mode for pure replay workflows, and reserve `auto` for cache-extend workflows with upstream configured).
+
+## Alternatives
+
+### Keep Existing Deferred Validation
+
+Allow `auto` without `live_responder` and fail only on MISS.
+
+- **Key characteristics**: validation deferred to request handling path.
+- **Pros**: supports replay-only HIT flows in `auto` mode.
+- **Cons**: weakens fail-fast guarantees and leaves invalid configuration undetected until runtime.
+- **Reason for rejection**: conflicts with determinism-first and fail-fast direction.
+
+### Require live_responder for Record Only
+
+Keep `record` strict, leave `auto` deferred.
+
+- **Key characteristics**: mixed validation semantics by mode.
+- **Pros**: preserves `auto` flexibility.
+- **Cons**: inconsistent validation model across forwarding-capable modes.
+- **Reason for rejection**: inconsistent API contracts increase cognitive load and hide misconfiguration.
+
+## Future Direction
+
+- Update release notes to mark this as a breaking change in `0.6.0`.
+- Ensure adapter examples and any external integrations configure `live_responder` whenever `auto` or `record` mode is used.
+- Revisit this decision only if a non-forwarding variant of `auto` is intentionally introduced as a separate mode with explicit semantics.
+
+## References
+
+- [ADR-0007: Broker Mode Parameter for Record Functionality](0007-broker-mode-parameter.md)
+- [ADR-0009: LiveResponder Port for Upstream Forwarding](0009-live-responder-port.md)
+- [ADR-0012: Cassette Save Failure Behavior](0012-cassette-save-failure-behavior.md)

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -105,3 +105,11 @@ Define fail-fast behavior when cassette persistence fails (save errors are propa
 **Status**: Accepted | **Date**: 2026-02-16
 
 Store implementations allow configuring missing-storage behavior at construction time: raise an error by default, or opt in to returning an empty cassette for record workflows.
+
+---
+
+### [ADR-0014: Require live_responder for Auto and Record Modes at Construction](../adr/0014-require-live-responder-for-auto-mode.md)
+
+**Status**: Accepted | **Date**: 2026-02-25
+
+Broker initialization now enforces that `record` and `auto` modes must be configured with a `live_responder`, providing fail-fast validation for deterministic workflows.

--- a/e2e/specs/persistence.spec
+++ b/e2e/specs/persistence.spec
@@ -65,3 +65,9 @@
 * Create broker from store in "auto" mode
 * Broker replays request for "test-proto" "fetch" "resource-999"
 * Response stream should contain "live-auto-data"
+
+## Broker created via from_store requires live responder in auto mode
+
+* Configure JSON file cassette store with create_if_missing at temporary path
+* Create broker from store in "auto" mode
+* Broker should raise LiveResponderRequiredError

--- a/e2e/specs/record.spec
+++ b/e2e/specs/record.spec
@@ -6,6 +6,18 @@
 * Broker in "replay" mode receives request for "test-proto" "fetch" "resource-123"
 * Broker should raise InteractionNotFoundError
 
+## Broker requires live responder in auto mode
+
+* Create empty cassette
+* Broker in "auto" mode receives request for "test-proto" "fetch" "resource-123"
+* Broker should raise LiveResponderRequiredError
+
+## Broker requires live responder in record mode
+
+* Create empty cassette
+* Broker in "record" mode receives request for "test-proto" "fetch" "resource-123"
+* Broker should raise LiveResponderRequiredError
+
 ## Broker forwards MISS to live upstream in auto mode
 
 * Create empty cassette

--- a/src/interposition/_version.py
+++ b/src/interposition/_version.py
@@ -1,3 +1,3 @@
 """Version information for interposition."""
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/src/interposition/services.py
+++ b/src/interposition/services.py
@@ -49,7 +49,8 @@ class Broker:
     Attributes:
         cassette: The cassette containing recorded interactions
         mode: The broker mode (replay, record, or auto)
-        live_responder: Optional callable for upstream forwarding
+        live_responder: Callable for upstream forwarding. Required when mode is
+            record or auto; optional in replay mode.
         cassette_store: Optional store for cassette persistence
     """
 
@@ -65,8 +66,13 @@ class Broker:
         Args:
             cassette: The cassette containing recorded interactions
             mode: The broker mode (replay, record, or auto)
-            live_responder: Optional callable for upstream forwarding
+            live_responder: Callable for upstream forwarding. Required when
+                mode is record or auto.
             cassette_store: Optional store for automatic cassette persistence
+
+        Raises:
+            LiveResponderRequiredError: When mode is record or auto and
+                live_responder is not configured.
         """
         if mode in ("record", "auto") and live_responder is None:
             raise LiveResponderRequiredError(mode)
@@ -88,7 +94,8 @@ class Broker:
         Args:
             cassette_store: The store to load the cassette from
             mode: The broker mode (replay, record, or auto)
-            live_responder: Optional callable for upstream forwarding
+            live_responder: Callable for upstream forwarding. Required when
+                mode is record or auto.
 
         Returns:
             A new Broker instance with the loaded cassette.
@@ -96,6 +103,8 @@ class Broker:
         Raises:
             CassetteLoadError: When the store fails to load the cassette
                 (e.g., missing file, corrupted data).
+            LiveResponderRequiredError: When mode is record or auto and
+                live_responder is not configured.
         """
         cassette = cassette_store.load()
         return cls(


### PR DESCRIPTION
# Pull Request Overview
This PR makes `live_responder` mandatory for `Broker` in `auto` and `record` modes, enforcing fail-fast validation at construction time. It moves configuration errors from runtime request handling to initialization, aligning with the project's determinism-first testing direction.

## Changes
- Enforce in `Broker.__init__`:
  - If `mode in {"auto", "record"}` and `live_responder is None`, raise `LiveResponderRequiredError`.
- Apply the same invariant to `Broker.from_store(...)` (via `__init__`).
- Add E2E coverage:
  - `auto`/`record` require `live_responder`.
  - `from_store(auto)` requires `live_responder`.
- Update unit tests:
  - Replace runtime-error expectations with constructor-time fail-fast expectations for missing `live_responder` in `auto`/`record`.
  - Add `from_store` fail-fast tests.
- Update documentation:
  - README error-handling section aligned with new behavior.
  - Add ADR-0014 for this decision.
  - Add ADR-0014 entry to architecture overview.
- Version bump: `0.5.0 -> 0.6.0`.

## Related Issues
Closes #15 

## Review Checklist
- [x] Version bump evaluated (is a minor/patch bump needed?)
- [ ] No breaking changes to public API (if any, is a major bump planned?)
  - This change is breaking (`auto` now requires `live_responder`).
  - The project is currently on `0.x`; this is reflected as a minor bump to `0.6.0`.
- [x] Documentation reflects all changes (README, API reference, E2E specs page)
- [x] No non-trivial design decisions left without an ADR
- [x] No existing ADR revisit triggers fired by this change

## Future Work
- Explicitly call out this breaking change in release notes.

## Notes
<!-- Any additional notes for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto and record modes now require a live_responder at broker initialization; LiveResponderRequiredError is raised immediately if not provided.

* **Documentation**
  * Updated error descriptions and added architecture decision record documenting live_responder requirements.

* **Tests**
  * Added test coverage validating live_responder requirement at initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->